### PR TITLE
Fixing snippet path generation

### DIFF
--- a/classes/hypeJunction/Snippets/Snippets.php
+++ b/classes/hypeJunction/Snippets/Snippets.php
@@ -50,8 +50,10 @@ class Snippets {
 		$view = "$snippet.twig";
 		$path = elgg_get_config('dataroot') . 'snippets/';
 
-		if (!is_dir($path)) {
-			mkdir($path, '0755');
+		$snippetpath = trim(pathinfo($snippet, PATHINFO_DIRNAME), ' .');
+		
+		if (!is_dir($path . $snippetpath)) {
+			mkdir($path . $snippetpath, 0755, true);
 		}
 
 		$filename = "{$path}{$view}";


### PR DESCRIPTION
Previously, snippets (often foo/bar) could not be saved, as only $dataroot/snippets/ was created. Additionally, because the permission mask was passed as a string, the directory was created in an unreadable format.

Solution was to recursively create snippet paths, and ensure that the path is created with the correct permissions.